### PR TITLE
Added populate scripts for coredata and metadata

### DIFF
--- a/bin/postman-test/DataDumps/command/deviceServiceDb.json
+++ b/bin/postman-test/DataDumps/command/deviceServiceDb.json
@@ -105,7 +105,7 @@
   "_class": "org.edgexfoundry.domain.meta.DeviceService",
   "adminState": "unlocked",
   "operatingState": "enabled",
-  "name": "home telxsi thermostat device service",
+  "name": "home telxsi thermostat device service #2",
   "description": "manage home thermostats",
   "lastConnected": 0,
   "lastReported": 0,

--- a/bin/postman-test/DataDumps/command/populate.sh
+++ b/bin/postman-test/DataDumps/command/populate.sh
@@ -1,0 +1,5 @@
+mongoimport -d metadata -c addressable --file addressableDb.json
+mongoimport -d metadata -c command --file commandDb.json
+mongoimport -d metadata -c device --file deviceDb.json
+mongoimport -d metadata -c deviceProfile --file deviceProfileDb.json
+mongoimport -d metadata -c deviceService --file deviceServiceDb.json

--- a/bin/postman-test/DataDumps/coredata/populate.sh
+++ b/bin/postman-test/DataDumps/coredata/populate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+mongoimport -d coredata -c event --file eventDb.json
+mongoimport -d coredata -c reading --file readingDb.json
+mongoimport -d coredata -c valueDescriptor --file valueDescriptorDb.json

--- a/bin/postman-test/DataDumps/metadata/populate.sh
+++ b/bin/postman-test/DataDumps/metadata/populate.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+mongoimport -d metadata -c addressable --file addressableDb.json
+mongoimport -d metadata -c command --file commandDb.json
+mongoimport -d metadata -c device --file deviceDb.json
+mongoimport -d metadata -c deviceProfile --file deviceProfileDb.json
+mongoimport -d metadata -c deviceReport --file deviceReportDb.json
+mongoimport -d metadata -c deviceService --file deviceserviceDb.json
+mongoimport -d metadata -c provisionWatcher --file provisioWatcherDb.json
+mongoimport -d metadata -c schedule --file scheduleDb.json
+mongoimport -d metadata -c scheduleEvent --file scheduleEventDb.json

--- a/bin/postman-test/DataDumps/metadata/scheduleDb.json
+++ b/bin/postman-test/DataDumps/metadata/scheduleDb.json
@@ -137,20 +137,6 @@
 }
 {
   "_id": {
-    "$oid": "57f6224de4b060e231e2e9ae"
-  },
-  "_class": "org.edgexfoundry.domain.meta.Schedule",
-  "name": "hourly",
-  "start": "1471824000",
-  "end": "1503360000",
-  "frequency": "60000",
-  "runOnce": false,
-  "created": 1475748429381,
-  "modified": 1475748429381,
-  "origin": 1471806386919
-}
-{
-  "_id": {
     "$oid": "57f62253e4b060e231e2e9b0"
   },
   "_class": "org.edgexfoundry.domain.meta.Schedule",


### PR DESCRIPTION
These are essential during testing because one has to clean out and repopulate Mongo over and over again.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>