### PR TITLE
Update rulesengine to 0.7.0 tag

### DIFF
--- a/bin/arm64_env.sh
+++ b/bin/arm64_env.sh
@@ -12,7 +12,7 @@ export coreCommand=nexus3.edgexfoundry.org:10004/docker-core-command-go-arm64:0.
 export supportLogging=nexus3.edgexfoundry.org:10004/docker-support-logging-go-arm64:0.7.0
 export supportNotifications=nexus3.edgexfoundry.org:10004/docker-support-notifications-go-arm64:0.7.0
 export supportScheduler=nexus3.edgexfoundry.org:10004/docker-support-scheduler-arm64:0.6.0
-export supportRulesengine=nexus3.edgexfoundry.org:10004/docker-support-rulesengine-arm64:0.6.0
+export supportRulesengine=nexus3.edgexfoundry.org:10004/docker-support-rulesengine-arm64:0.7.0
 
 export exportClient=nexus3.edgexfoundry.org:10004/docker-export-client-go-arm64:0.7.0
 export exportDistro=nexus3.edgexfoundry.org:10004/docker-export-distro-go-arm64:0.7.0

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -12,7 +12,7 @@ export coreCommand=nexus3.edgexfoundry.org:10004/docker-core-command-go:0.7.0
 export supportLogging=nexus3.edgexfoundry.org:10004/docker-support-logging-go:0.7.0
 export supportNotifications=nexus3.edgexfoundry.org:10004/docker-support-notifications-go:0.7.0
 export supportScheduler=nexus3.edgexfoundry.org:10004/docker-support-scheduler:0.6.0
-export supportRulesengine=nexus3.edgexfoundry.org:10004/docker-support-rulesengine:0.6.0
+export supportRulesengine=nexus3.edgexfoundry.org:10004/docker-support-rulesengine:0.7.0
 
 export exportClient=nexus3.edgexfoundry.org:10004/docker-export-client-go:0.7.0
 export exportDistro=nexus3.edgexfoundry.org:10004/docker-export-distro-go:0.7.0


### PR DESCRIPTION
rulesengine 0.7.0 tags are now available in nexus3.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>