### PR TITLE
Issue 128 - Update core-metadata device service test result for UUID return length

### DIFF
--- a/bin/postman-test/collections/core-metadata.postman_collection.json
+++ b/bin/postman-test/collections/core-metadata.postman_collection.json
@@ -7310,7 +7310,7 @@
 									"            tests[\"Content-Type is \"+data.ApplicationTextPlainType] =  responseHeaders[\"Content-Type\"].has(data.ApplicationTextPlainType);",
 									"        }",
 									"        if(null !== responseBody){",
-									"            tests[\"Response Object id\"] = responseBody.length === 24;",
+									"            tests[\"Response Object id\"] = responseBody.length === 36;",
 									"        } else{",
 									"            tests[\"Response list is empty\"] = responseBody.length === 0",
 									"        }",


### PR DESCRIPTION
Issue 128 - Update core-metadata device service test result for UUID return length

* Updates length of expected test result to accommodate change from bson.ObjectId.Hex() to uuid.

Signed-off-by: Michael W. Estrin <me@michaelestrin.com>