### PR TITLE
Change expected DeviceProfile ID length

### DIFF
--- a/bin/postman-test/collections/core-metadata.postman_collection.json
+++ b/bin/postman-test/collections/core-metadata.postman_collection.json
@@ -4943,7 +4943,7 @@
 									"            tests[\"Content-Type is \"+data.ApplicationTextPlainType] =  responseHeaders[\"Content-Type\"].has(data.ApplicationTextPlainType);",
 									"        }",
 									"        if(null !== responseBody){",
-									"            tests[\"Response Object id\"] = responseBody.length === 24;",
+									"            tests[\"Response Object id\"] = responseBody.length === 36;",
 									"        } else{",
 									"            tests[\"Response list is empty\"] = responseBody.length === 0",
 									"        }",


### PR DESCRIPTION
As part of Edgex-Go #878 ( https://github.com/edgexfoundry/edgex-go/pull/999 ), Ids are now UUIDs by default, not BSON ObjectIds.  This change adjusts the expected length of a created DeviceProfile's Id.

Signed-off-by: Daniel Harms <jdharms@gmail.com>