### PR TITLE
Issue #880 - core-metadata Device: Eliminate Mongo Types from Models

### DIFF
--- a/bin/postman-test/collections/core-metadata.postman_collection.json
+++ b/bin/postman-test/collections/core-metadata.postman_collection.json
@@ -3188,7 +3188,7 @@
 									"        tests[\"Content-Type is \"+data.TextPlainContentType] =  responseHeaders[\"Content-Type\"].has(data.TextPlainContentType);",
 									"    }",
 									"    //Test body value",
-									"    tests[\"Is Body Contains Id\"] = responseBody.length === 24;",
+									"    tests[\"Is Body Contains Id\"] = responseBody.length === 36;",
 									"}"
 								]
 							}


### PR DESCRIPTION
* Updates length of expected test result to accommodate change from bson.ObjectId.Hex() to uuid.

Signed-off-by: Michael W. Estrin <me@michaelestrin.com>

https://github.com/edgexfoundry/edgex-go/issues/880