### PR TITLE
Remove Header on upload deviceprofile api

### DIFF
--- a/bin/postman-test/collections/core-metadata.postman_collection.json
+++ b/bin/postman-test/collections/core-metadata.postman_collection.json
@@ -4077,12 +4077,7 @@
 					],
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded"
-							}
-						],
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [


### PR DESCRIPTION
Remove Header on upload deviceprofile api.
Signed-off-by: Cherry Wang <cherry@iotechsys.com>
Fix #254 