### PR TITLE
update kong image

### DIFF
--- a/bin/arm64_env.sh
+++ b/bin/arm64_env.sh
@@ -22,7 +22,7 @@ export appService=nexus3.edgexfoundry.org:10004/docker-app-service-configurable-
 export vault=nexus3.edgexfoundry.org:10004/docker-edgex-vault-arm64:0.3.0
 export vaultWorker=nexus3.edgexfoundry.org:10004/docker-edgex-vault-worker-go-arm64:0.3.0
 export kongdb=postgres:9.5
-export kong=nexus3.edgexfoundry.org:10003/kong-arm:latest
+export kong=kong:1.3.0-ubuntu
 export edgexProxy=nexus3.edgexfoundry.org:10004/docker-edgex-proxy-go-arm64:1.1.0
 
 export postman=nexus3.edgexfoundry.org:10004/postman-newman-arm64:3.9.4

--- a/bin/arm64_env.sh
+++ b/bin/arm64_env.sh
@@ -22,7 +22,7 @@ export appService=nexus3.edgexfoundry.org:10004/docker-app-service-configurable-
 export vault=nexus3.edgexfoundry.org:10004/docker-edgex-vault-arm64:0.3.0
 export vaultWorker=nexus3.edgexfoundry.org:10004/docker-edgex-vault-worker-go-arm64:0.3.0
 export kongdb=postgres:9.5
-export kong=nexus3.edgexfoundry.org:10004/kong-arm:14
+export kong=nexus3.edgexfoundry.org:10003/kong-arm:latest
 export edgexProxy=nexus3.edgexfoundry.org:10004/docker-edgex-proxy-go-arm64:0.2.1
 
 export postman=nexus3.edgexfoundry.org:10004/postman-newman-arm64:3.9.4

--- a/bin/arm64_env.sh
+++ b/bin/arm64_env.sh
@@ -23,6 +23,6 @@ export vault=nexus3.edgexfoundry.org:10004/docker-edgex-vault-arm64:0.3.0
 export vaultWorker=nexus3.edgexfoundry.org:10004/docker-edgex-vault-worker-go-arm64:0.3.0
 export kongdb=postgres:9.5
 export kong=nexus3.edgexfoundry.org:10003/kong-arm:latest
-export edgexProxy=nexus3.edgexfoundry.org:10004/docker-edgex-proxy-go-arm64:0.2.1
+export edgexProxy=nexus3.edgexfoundry.org:10004/docker-edgex-proxy-go-arm64:1.1.0
 
 export postman=nexus3.edgexfoundry.org:10004/postman-newman-arm64:3.9.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
     environment:
         - 'KONG_DATABASE=postgres'
         - 'KONG_PG_HOST=kong-db'
-    command: "kong migrations up"
+    command: "kong migrations bootstrap || kong migrations up"
 
   kong:
     image: ${kong}


### PR DESCRIPTION
I am updating the arm64_env file to update the docker kong image to the latest arm64 based version. This is an attempt to fix the `exec format error` due to the previous image being based on 32bit arm. The build of the image can be found here: https://jenkins.edgexfoundry.org/view/CI-Build-Images/job/ci-build-images-kong-merge-pipeline/64/

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>