### PR TITLE
core-command device tests missing required parameter

### DIFF
--- a/bin/postman-test/collections/core-command.postman_collection.json
+++ b/bin/postman-test/collections/core-command.postman_collection.json
@@ -291,7 +291,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\"RandomValue_Int8\": \"26\"}"
+							"raw": "{\"RandomValue_Int8\": \"26\", \"EnableRandomization_Int8\": \"false\"}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/v1/device/{{getDeviceById}}/command/{{getCommandById}}",
@@ -513,7 +513,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\"RandomValue_Int8\":\"72\"}"
+							"raw": "{\"RandomValue_Int8\":\"72\",\"EnableRandomization_Int8\":\"false\"}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/v1/device/name/{{DeviceName}}/command/{{CommandName}}",


### PR DESCRIPTION
Adds missing EnableRandomization_Int8 parameter for tests 21_200 and
31_200.

https://github.com/edgexfoundry/blackbox-testing/issues/287

Signed-off-by: Michael W. Estrin <me@michaelestrin.com>