### PR TITLE
Fix Docker Compose files to bypass security

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export volume=nexus3.edgexfoundry.org:10004/docker-edgex-volume:1.0.0
+export volume=nexus3.edgexfoundry.org:10004/docker-edgex-volume:1.1.0
 export consul=consul:1.3.1
 export configSeed=nexus3.edgexfoundry.org:10004/docker-core-config-seed-go:1.1.0
 export mongo=nexus3.edgexfoundry.org:10004/docker-edgex-mongo:1.1.0
@@ -26,4 +26,3 @@ export kong=kong:1.0.3
 export edgexProxy=nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:1.1.0
 
 export postman=postman/newman
-

--- a/deploy-edgeX.sh
+++ b/deploy-edgeX.sh
@@ -22,7 +22,7 @@
 #    echo " os =  ${OS}"
 #    . $(dirname "$0")/bin/env-win10.sh
 #else
-#    . $(dirname "$0")/bin/env.sh	
+#    . $(dirname "$0")/bin/env.sh
 #fi
 
 run_service () {
@@ -35,9 +35,9 @@ run_service consul
 
 run_service config-seed
 
-if [ "$SECURITY_SERVICE_NEEDED" = "true" ]; then
 
-	run_service consul
+
+if [ "$SECURITY_SERVICE_NEEDED" = "true" ]; then
 
 	run_service vault
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,11 @@
 #  * added: Jun 30, 2019
 #  *******************************************************************************/
 
-version: '3'
+version: '3.4'
+# all common shared environment variables defined here:
+x-common-env-variables: &common-variables
+  EDGEX_SECURITY_SECRET_STORE: "false"
+
 volumes:
   db-data:
   log-data:
@@ -68,6 +72,8 @@ services:
       edgex-network:
         aliases:
           - edgex-core-config-seed
+    environment:
+      <<: *common-variables
     volumes:
       - db-data:/data/db
       - log-data:/edgex/logs
@@ -224,6 +230,8 @@ services:
       edgex-network:
         aliases:
           - edgex-mongo
+    environment:
+      <<: *common-variables
     volumes:
       - vault-config:/vault/config
       - newman:/etc/newman
@@ -241,6 +249,8 @@ services:
       edgex-network:
         aliases:
           - edgex-support-logging
+    environment:
+      <<: *common-variables
     volumes:
       - db-data:/data/db
       - log-data:/edgex/logs
@@ -261,6 +271,8 @@ services:
       edgex-network:
         aliases:
           - edgex-support-notifications
+    environment:
+      <<: *common-variables
     volumes:
       - db-data:/data/db
       - log-data:/edgex/logs
@@ -279,6 +291,8 @@ services:
       edgex-network:
         aliases:
           - edgex-core-metadata
+    environment:
+      <<: *common-variables
     volumes:
       - db-data:/data/db
       - log-data:/edgex/logs
@@ -298,6 +312,8 @@ services:
       edgex-network:
         aliases:
           - edgex-core-data
+    environment:
+      <<: *common-variables
     volumes:
       - db-data:/data/db
       - log-data:/edgex/logs
@@ -316,6 +332,8 @@ services:
       edgex-network:
         aliases:
           - edgex-core-command
+    environment:
+      <<: *common-variables
     volumes:
       - db-data:/data/db
       - log-data:/edgex/logs
@@ -334,6 +352,8 @@ services:
       edgex-network:
         aliases:
           - edgex-support-scheduler
+    environment:
+      <<: *common-variables
     volumes:
       - db-data:/data/db
       - log-data:/edgex/logs
@@ -352,6 +372,8 @@ services:
       edgex-network:
         aliases:
           - edgex-export-client
+    environment:
+      <<: *common-variables
     volumes:
       - db-data:/data/db
       - log-data:/edgex/logs
@@ -379,12 +401,12 @@ services:
     depends_on:
       - export-client
     environment:
-      - EXPORT_DISTRO_CLIENT_HOST=export-client
-      - EXPORT_DISTRO_DATA_HOST=edgex-core-data
-      - EXPORT_DISTRO_CONSUL_HOST=edgex-config-seed
-      - EXPORT_DISTRO_MQTTS_CERT_FILE=none
-      - EXPORT_DISTRO_MQTTS_KEY_FILE=none
-
+      EXPORT_DISTRO_CLIENT_HOST: export-client
+      EXPORT_DISTRO_DATA_HOST: edgex-core-data
+      EXPORT_DISTRO_CONSUL_HOST: edgex-config-seed
+      EXPORT_DISTRO_MQTTS_CERT_FILE: none
+      EXPORT_DISTRO_MQTTS_KEY_FILE: none
+      <<: *common-variables
   rulesengine:
     image: ${supportRulesengine}
     ports:


### PR DESCRIPTION
Update docker-compose to properly inject the necessary environment
variables needed to create an EdgeX system without security.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>