### PR TITLE
Update scripts for security issue

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -24,7 +24,7 @@ APPSERVICECONFIGURABLELOGSPATH=$BASEPATH/appserviceconfigurable$TIMESTAMPFORMAT.
 EDGEXLOGSPATH=$BASEPATH/edgex$TIMESTAMPFORMAT.log
 
 securityTest() {
-	. $(dirname "$0")/setupSecurityserviceTest.sh
+	$(dirname "$0")/setupSecurityserviceTest.sh
 	$(dirname "$0")/runSecurityserviceTest.sh
 	$(dirname "$0")/cleanSecurityserviceTest.sh
 }

--- a/deploy-edgeX.sh
+++ b/deploy-edgeX.sh
@@ -45,7 +45,9 @@ if [ "$SECURITY_SERVICE_NEEDED" = "true" ]; then
 
 	run_service kong-db
 
-	run_service kong-migration
+	sleep 10s
+
+	run_service kong-migrations
 
 	sleep 10s
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,7 @@ services:
       - vault-file:/vault/file
       - vault-logs:/vault/logs
       - secrets-setup-cache:/etc/edgex/pki
+      - vault-config:/vault/config
       - /run/edgex/secrets/edgex-vault:/run/edgex/secrets/edgex-vault
     depends_on:
       - volume


### PR DESCRIPTION
1. Fixed executing shell script error.
2. Fixed fail to start kong-migrations.
3. Fixed error "can't open '/vault/config/assets/resp-init.json': No such file or directory"

Signed-off-by: Cherry Wang <cherry@iotechsys.com>