### PR TITLE
Update to leverage security environment variable

### DIFF
--- a/deploy-edgeX.sh
+++ b/deploy-edgeX.sh
@@ -30,7 +30,14 @@ run_service () {
 	docker-compose up -d $1
 }
 
+if [ "$SECURITY_SERVICE_NEEDED" = "true" ]; then
+	export SECURITY_IS_ON="true"
+else
+	export SECURITY_IS_ON="false"
+fi
+
 run_service volume
+
 run_service consul
 
 run_service config-seed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@
 version: '3.4'
 # all common shared environment variables defined here:
 x-common-env-variables: &common-variables
-  EDGEX_SECURITY_SECRET_STORE: "false"
+  EDGEX_SECURITY_SECRET_STORE: ${SECURITY_IS_ON}
 
 volumes:
   db-data:


### PR DESCRIPTION
Fix #294

Update deploy script and Docker Compose file to leverage the
'EDGEX_SECURITY_SECRET_STORE' environment variable to disable security.
Also, update the deploy script to match the rest of EdgeX by enabling
security by default unless the 'EDGEX_SECURITY_SECRET_STORE' environment
variable is explicitly set to 'false'.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>