### PR TITLE
arm64 non-security Jenkins build rules-engine test failures

### DIFF
--- a/bin/arm64_env.sh
+++ b/bin/arm64_env.sh
@@ -12,7 +12,7 @@ export coreCommand=nexus3.edgexfoundry.org:10004/docker-core-command-go-arm64:1.
 export supportLogging=nexus3.edgexfoundry.org:10004/docker-support-logging-go-arm64:1.1.0
 export supportNotifications=nexus3.edgexfoundry.org:10004/docker-support-notifications-go-arm64:1.1.0
 export supportScheduler=nexus3.edgexfoundry.org:10004/docker-support-scheduler-go-arm64:1.1.0
-export supportRulesengine=nexus3.edgexfoundry.org:10004/docker-support-rulesengine-arm64:1.0.0
+export supportRulesengine=nexus3.edgexfoundry.org:10004/docker-support-rulesengine-arm64::1.1.0-dev.1
 
 export exportClient=nexus3.edgexfoundry.org:10004/docker-export-client-go-arm64:1.1.0
 export exportDistro=nexus3.edgexfoundry.org:10004/docker-export-distro-go-arm64:1.1.0

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -12,7 +12,7 @@ export coreCommand=nexus3.edgexfoundry.org:10004/docker-core-command-go:1.1.0
 export supportLogging=nexus3.edgexfoundry.org:10004/docker-support-logging-go:1.1.0
 export supportNotifications=nexus3.edgexfoundry.org:10004/docker-support-notifications-go:1.1.0
 export supportScheduler=nexus3.edgexfoundry.org:10004/docker-support-scheduler-go:1.1.0
-export supportRulesengine=nexus3.edgexfoundry.org:10004/docker-support-rulesengine:1.0.0
+export supportRulesengine=nexus3.edgexfoundry.org:10004/docker-support-rulesengine::1.1.0-dev.1
 
 export exportClient=nexus3.edgexfoundry.org:10004/docker-export-client-go:1.1.0
 export exportDistro=nexus3.edgexfoundry.org:10004/docker-export-distro-go:1.1.0


### PR DESCRIPTION
Updated rules engine images to use same images as developer-scripts
docker-compose files.

Fixes: https://github.com/edgexfoundry/blackbox-testing/issues/296

Signed-off-by: Michael W. Estrin <me@michaelestrin.com>