### PR TITLE
Add logging to deploy-edgeX script

### DIFF
--- a/bin/arm64_env.sh
+++ b/bin/arm64_env.sh
@@ -12,7 +12,7 @@ export coreCommand=nexus3.edgexfoundry.org:10004/docker-core-command-go-arm64:1.
 export supportLogging=nexus3.edgexfoundry.org:10004/docker-support-logging-go-arm64:1.1.0
 export supportNotifications=nexus3.edgexfoundry.org:10004/docker-support-notifications-go-arm64:1.1.0
 export supportScheduler=nexus3.edgexfoundry.org:10004/docker-support-scheduler-go-arm64:1.1.0
-export supportRulesengine=nexus3.edgexfoundry.org:10004/docker-support-rulesengine-arm64::1.1.0-dev.1
+export supportRulesengine=nexus3.edgexfoundry.org:10004/docker-support-rulesengine-arm64:1.0.0
 
 export exportClient=nexus3.edgexfoundry.org:10004/docker-export-client-go-arm64:1.1.0
 export exportDistro=nexus3.edgexfoundry.org:10004/docker-export-distro-go-arm64:1.1.0

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -12,7 +12,7 @@ export coreCommand=nexus3.edgexfoundry.org:10004/docker-core-command-go:1.1.0
 export supportLogging=nexus3.edgexfoundry.org:10004/docker-support-logging-go:1.1.0
 export supportNotifications=nexus3.edgexfoundry.org:10004/docker-support-notifications-go:1.1.0
 export supportScheduler=nexus3.edgexfoundry.org:10004/docker-support-scheduler-go:1.1.0
-export supportRulesengine=nexus3.edgexfoundry.org:10004/docker-support-rulesengine::1.1.0-dev.1
+export supportRulesengine=nexus3.edgexfoundry.org:10004/docker-support-rulesengine:1.0.0
 
 export exportClient=nexus3.edgexfoundry.org:10004/docker-export-client-go:1.1.0
 export exportDistro=nexus3.edgexfoundry.org:10004/docker-export-distro-go:1.1.0

--- a/deploy-edgeX.sh
+++ b/deploy-edgeX.sh
@@ -27,10 +27,6 @@
 
 run_service () {
 	echo "\033[0;32mStarting.. $1\033[0m"
-	echo "-------------------------- ENVIRONMENT VARIABLES -----------------------"
-	env
-	echo "------------------------------------------------------------------------"
-
 	docker-compose up -d $1
 }
 
@@ -46,11 +42,11 @@ run_service consul
 
 run_service config-seed
 
-
-
 if [ "$SECURITY_SERVICE_NEEDED" = "true" ]; then
 
 	run_service vault
+
+	sleep 20s
 
 	run_service vault-worker
 
@@ -95,14 +91,46 @@ run_service app-service-configurable
 
 sleep 100s # Wait for rulesengine fully startup, because it takes around 100s on Raspberry Pi
 
-echo "-------------------------- MONGO -----------------------"
+echo "------- volume ------"
+docker logs edgex-files
+echo "------- consul ------"
+docker logs edgex-core-consul
+echo "------- config-seed ------"
+docker logs edgex-config-seed
+echo "------- vault ------"
+docker logs edgex-vault
+echo "------- vault-worker ------"
+docker logs edgex-vault-worker
+echo "------- kong-db ------"
+docker logs kong-db
+echo "------- kong-migrations ------"
+docker logs kong-migration
+echo "------- kong ------"
+docker logs kong
+echo "------- edgex-proxy ------"
+docker logs edgex-proxy
+echo "------- mongo ------"
 docker logs edgex-mongo
-echo "---------------------------------------------------------"
-
-echo "-------------------------- CORE DATA -----------------------"
+echo "------- logging ------"
+docker logs edgex-support-logging
+echo "------- data ------"
 docker logs edgex-core-data
-echo "-------------------------------------------------------------"
-
-echo "-------------------------- CORE METADATA -----------------------"
+echo "------- export-client ------"
+docker logs edgex-export-client
+echo "------- export-distro ------"
+docker logs edgex-export-distro
+echo "------- rulesengine ------"
+docker logs edgex-support-rulesengine
+echo "------- notifications ------"
+docker logs edgex-support-notifications
+echo "------- metadata ------"
 docker logs edgex-core-metadata
-echo "------------------------------------------------------------------"
+echo "------- command ------"
+docker logs edgex-core-command
+echo "------- scheduler ------"
+docker logs edgex-support-scheduler
+echo "------- device-virtual ------"
+docker logs edgex-device-virtual
+echo "------- app-service-configurable ------"
+docker logs edgex-app-service-configurable
+echo "---------------------------------------------------------"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       - VAULT_CONFIG_DIR=/vault/config
       - VAULT_UI=true
     tmpfs:
-      - /run
+      - /run/edgex/secrets/edgex-vault
     command: >
       /usr/bin/dumb-init -- /bin/sh -c
       "./security-secrets-setup generate ;
@@ -131,7 +131,6 @@ services:
       - vault-logs:/vault/logs
       - secrets-setup-cache:/etc/edgex/pki
       - vault-config:/vault/config
-      - /run/edgex/secrets/edgex-vault:/run/edgex/secrets/edgex-vault
     depends_on:
       - volume
       - consul
@@ -140,7 +139,7 @@ services:
     image: ${vaultWorker}
     container_name: edgex-vault-worker
     hostname: edgex-vault-worker
-    command: ["--init=true", "--vaultInterval=10", "--insecureSkipVerify=false"]
+    command: ["--init=true", "--vaultInterval=10", "--insecureSkipVerify=true"]
     networks:
       edgex-network:
         aliases:
@@ -208,6 +207,7 @@ services:
     image: ${edgexProxy}
     container_name: edgex-proxy
     hostname: edgex-proxy
+    command: ["--init=true", "--insecureSkipVerify=true"]
     networks:
       edgex-network:
         aliases:
@@ -415,6 +415,7 @@ services:
       EXPORT_DISTRO_MQTTS_CERT_FILE: none
       EXPORT_DISTRO_MQTTS_KEY_FILE: none
       <<: *common-variables
+
   rulesengine:
     image: ${supportRulesengine}
     ports:


### PR DESCRIPTION
This commit is part of #282 in
edgex-go(https://github.com/edgexfoundry/blackbox-testing/issues/282)

Add information to print docker container logs within the Jenkins
pipeline job for easier troubleshooting.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>