### PR TITLE
remove host header in requests;change proxy image name

### DIFF
--- a/bin/cleanSecurityserviceTest.sh
+++ b/bin/cleanSecurityserviceTest.sh
@@ -2,6 +2,6 @@
 
 echo "Info: Clean Securityservice's test data."
 
-docker-compose run edgex-proxy --userdel=jerry
+docker-compose run edgex-proxy --init=false --userdel=jerry
 
 echo "Info: Securityservice's test data Cleaned"

--- a/bin/flushSecurityserviceDump.sh
+++ b/bin/flushSecurityserviceDump.sh
@@ -8,6 +8,6 @@ echo "Info: Clean Securityservice's test data."
 
 docker-compose run --rm postman run ${COLLECTION_PATH} --environment=${ENV_PATH}
 
-docker run –-network=${DOCKER_NETWORK} edgexfoundry/docker-edgex-proxy-go --userdel=jerry
+docker run –-network=${DOCKER_NETWORK} edgexfoundry/docker-edgex-security-proxy-setup-go --init=false --userdel=jerry
 
 echo "Info: Securityservice's test data Cleaned"

--- a/bin/postman-test/collections/security-apigateway.postman_collection.json
+++ b/bin/postman-test/collections/security-apigateway.postman_collection.json
@@ -1,13 +1,12 @@
 {
 	"info": {
-		"_postman_id": "75caac77-e281-4969-bfeb-a9f573b75747",
+		"_postman_id": "ea100c42-a49e-41a8-9301-f0083b3ab3b8",
 		"name": "security-apigateway",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
 			"name": "reading",
-			"description": "Folder for reading",
 			"item": [
 				{
 					"name": "01 http://localhost:8000/coredata/api/v1/reading",
@@ -16,7 +15,6 @@
 							"listen": "test",
 							"script": {
 								"id": "14d7c4e1-db68-4815-ac50-72d060450b19",
-								"type": "text/javascript",
 								"exec": [
 									"/*",
 									" * Test Case:  /api/v1/reading - GET",
@@ -57,22 +55,14 @@
 									"            tests[\"Is Reading list empty\"] = actualReadingData.length === 0",
 									"        }",
 									"    }"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
 					"request": {
 						"method": "GET",
-						"header": [
-							{
-								"key": "host",
-								"value": "edgex.com"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
+						"header": [],
 						"url": {
 							"raw": "{{baseUrlcoredata}}/api/v1/reading",
 							"host": [
@@ -95,7 +85,6 @@
 							"listen": "test",
 							"script": {
 								"id": "d0f93a20-9b5f-4d7a-b234-1eaf10501e68",
-								"type": "text/javascript",
 								"exec": [
 									"/*",
 									" * Test Case:  /api/v1/reading - PUT",
@@ -122,14 +111,14 @@
 									"            tests[\"Body has True\"] = responseBody === \"true\";",
 									"    }",
 									"}"
-								]
+								],
+								"type": "text/javascript"
 							}
 						},
 						{
 							"listen": "prerequest",
 							"script": {
 								"id": "426796ec-0865-4245-8143-04da02969b1b",
-								"type": "text/javascript",
 								"exec": [
 									"var baseUrl = pm.environment.get(\"baseUrlcoredata\");",
 									"var data = {",
@@ -149,7 +138,8 @@
 									"pm.sendRequest(request, function (err, res) {",
 									"    pm.environment.set(\"readingID\", res.stream.toString());",
 									"});"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -159,10 +149,6 @@
 							{
 								"key": "Content-Type",
 								"value": "application/json"
-							},
-							{
-								"key": "host",
-								"value": "edgex.com"
 							}
 						],
 						"body": {
@@ -191,7 +177,6 @@
 							"listen": "test",
 							"script": {
 								"id": "6f7b9896-601f-4461-aa59-300fb8a9824f",
-								"type": "text/javascript",
 								"exec": [
 									"/*",
 									" * Test Case:  /api/v1/reading - POST",
@@ -209,7 +194,8 @@
 									"//if(null !== responseBody){",
 									"//    tests[\"Response Object id\"] = responseBody.length === 36;",
 									"//}"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -219,10 +205,6 @@
 							{
 								"key": "Content-Type",
 								"value": "application/json"
-							},
-							{
-								"key": "host",
-								"value": "edgex.com"
 							}
 						],
 						"body": {
@@ -244,11 +226,12 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"description": "Folder for reading",
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "reading_error_4xx",
-			"description": "Folder for reading",
 			"item": [
 				{
 					"name": "01 http://localhost:8000/coredata/api/v1/reading",
@@ -256,14 +239,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "f2b59fe2-a388-4f73-85a1-59a7c00d92ea",
 								"exec": [
 									"//Assert 404 status if the reading cannot be found by id",
 									"tests[\"Status code is 404\"] = responseCode.code === 404;",
 									"tests[\"Response time is less than \"+data.responseTime+\"ms\"] = responseTime < data.responseTime;",
 									"",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -273,10 +257,6 @@
 							{
 								"key": "Content-Type",
 								"value": "application/json"
-							},
-							{
-								"key": "host",
-								"value": "edgex.com"
 							}
 						],
 						"body": {
@@ -298,11 +278,12 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"description": "Folder for reading",
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "ping",
-			"description": "Folder for ping",
 			"item": [
 				{
 					"name": "01 http://localhost:8000/coredata/api/v1/ping",
@@ -311,7 +292,6 @@
 							"listen": "test",
 							"script": {
 								"id": "33b870f7-d713-48ed-9c68-496b7ef5beea",
-								"type": "text/javascript",
 								"exec": [
 									" /**",
 									" * Test Case:  /api/v1/ping - GET",
@@ -332,22 +312,14 @@
 									"          //  tests[\"Body is correct\"] = responseBody === \"pong\";",
 									"        //}",
 									"    }"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
 					"request": {
 						"method": "GET",
-						"header": [
-							{
-								"key": "host",
-								"value": "edgex.com"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
+						"header": [],
 						"url": {
 							"raw": "{{baseUrlcoredata}}/api/v1/ping",
 							"host": [
@@ -362,16 +334,119 @@
 						"description": "Test service providing an indication that the service is available."
 					},
 					"response": []
+				},
+				{
+					"name": "02 https://localhost:8001/services",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "2bf5e87d-9b32-4514-b973-934db4f8f7fa",
+								"exec": [
+									" /**",
+									" * Test Case:  /services - GET",
+									" * Version: Alpha",
+									" * @Author: Tingyu Zeng",
+									" * ",
+									" **/",
+									" ",
+									" tests[\"Ping Failure due to missing access token\"] = responseCode.code === 401;",
+									" tests[\"Response time is less than \"+data.responseTime+\"ms\"] = responseTime < data.responseTime;",
+									" //if(responseCode.code === 200){",
+									"   //     var contentTypeHeaderExists = responseHeaders.hasOwnProperty(\"Content-Type\");",
+									"     //   tests[\"Has Content-Type\"] = contentTypeHeaderExists;",
+									"       // if (contentTypeHeaderExists) {",
+									"        //tests[\"Content-Type is text/plain\"] =  responseHeaders[\"Content-Type\"].has(\"text/plain\");",
+									"        //}",
+									"        //if(responseBody.length!== 0){",
+									"         //   tests[\"Body is correct\"] = responseBody === \"pong\";",
+									"        //}",
+									"    //}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://localhost:8001/services",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "8001",
+							"path": [
+								"services"
+							]
+						},
+						"description": "Test service providing an indication that the service is available."
+					},
+					"response": []
+				},
+				{
+					"name": "03 http://localhost:8000/coredata/api/v1/ping",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "2bf5e87d-9b32-4514-b973-934db4f8f7fa",
+								"exec": [
+									" /**",
+									" * Test Case:  /services - GET",
+									" * Version: Alpha",
+									" * @Author: Tingyu Zeng",
+									" * ",
+									" **/",
+									" ",
+									" tests[\"Ping Failure due to missing access token\"] = responseCode.code === 401;",
+									" tests[\"Response time is less than \"+data.responseTime+\"ms\"] = responseTime < data.responseTime;",
+									" //if(responseCode.code === 200){",
+									"   //     var contentTypeHeaderExists = responseHeaders.hasOwnProperty(\"Content-Type\");",
+									"     //   tests[\"Has Content-Type\"] = contentTypeHeaderExists;",
+									"       // if (contentTypeHeaderExists) {",
+									"        //tests[\"Content-Type is text/plain\"] =  responseHeaders[\"Content-Type\"].has(\"text/plain\");",
+									"        //}",
+									"        //if(responseBody.length!== 0){",
+									"         //   tests[\"Body is correct\"] = responseBody === \"pong\";",
+									"        //}",
+									"    //}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8000/coredata/api/v1/ping",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8000",
+							"path": [
+								"coredata",
+								"api",
+								"v1",
+								"ping"
+							]
+						},
+						"description": "Test service providing an indication that the service is available."
+					},
+					"response": []
 				}
-			]
+			],
+			"description": "Folder for ping",
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "api-gateway",
-			"description": "",
 			"item": [
 				{
 					"name": "Health Check",
-					"description": "",
 					"item": [
 						{
 							"name": "01 http://localhost:8001/services",
@@ -380,7 +455,6 @@
 									"listen": "test",
 									"script": {
 										"id": "b36ac77f-cc53-41ce-b871-7056ad468733",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /services - GET",
@@ -401,22 +475,14 @@
 											"        //    tests[\"Body is correct\"] = responseBody === \"pong\";",
 											"        //}",
 											"    }"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "{{baseUrl}}/services",
 									"host": [
@@ -437,7 +503,6 @@
 									"listen": "test",
 									"script": {
 										"id": "41a1010b-84c9-42d6-b469-2ef6b16f0140",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /routes - GET",
@@ -458,22 +523,14 @@
 											"        //    tests[\"Body is correct\"] = responseBody === \"pong\";",
 											"        //}",
 											"    }"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "{{baseUrl}}/routes",
 									"host": [
@@ -522,10 +579,6 @@
 							"request": {
 								"method": "GET",
 								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{baseUrl}}/v1/sys/health",
 									"host": [
@@ -542,11 +595,11 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
 					"name": "Proxy Check",
-					"description": "",
 					"item": [
 						{
 							"name": "01 https://localhost:8443/coredata/api/v1/ping",
@@ -555,7 +608,6 @@
 									"listen": "test",
 									"script": {
 										"id": "4ba89122-5c04-4e01-9019-ba669ebbac53",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /services - GET",
@@ -566,27 +618,14 @@
 											" ",
 											" tests[\"Ping Failure due to missing access token\"] = responseCode.code === 401;",
 											" tests[\"Response time is less than \"+data.responseTime+\"ms\"] = responseTime < data.responseTime;"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									},
-									{
-										"key": "",
-										"value": "",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "https://localhost:8443/coredata/api/v1/ping",
 									"protocol": "https",
@@ -612,7 +651,6 @@
 									"listen": "test",
 									"script": {
 										"id": "4835cce9-7992-43bc-b1cc-1a46ba8192af",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /services - GET",
@@ -633,7 +671,8 @@
 											"           tests[\"Body is correct\"] = responseBody === \"pong\";",
 											"        }",
 											"    }"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -649,21 +688,7 @@
 									]
 								},
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									},
-									{
-										"key": "",
-										"value": "",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "https://localhost:8443/coredata/api/v1/ping",
 									"protocol": "https",
@@ -689,7 +714,6 @@
 									"listen": "test",
 									"script": {
 										"id": "2bf5e87d-9b32-4514-b973-934db4f8f7fa",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /services - GET",
@@ -710,22 +734,14 @@
 											"         //   tests[\"Body is correct\"] = responseBody === \"pong\";",
 											"        //}",
 											"    //}"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "http://localhost:8000/coredata/api/v1/ping",
 									"protocol": "http",
@@ -751,7 +767,6 @@
 									"listen": "test",
 									"script": {
 										"id": "2bf5e87d-9b32-4514-b973-934db4f8f7fa",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /services - GET",
@@ -772,22 +787,14 @@
 											"         //   tests[\"Body is correct\"] = responseBody === \"pong\";",
 											"        //}",
 											"    //}"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "http://localhost:8001/services",
 									"protocol": "http",
@@ -804,11 +811,11 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
 					"name": "SecretStore Check",
-					"description": "",
 					"item": [
 						{
 							"name": "01 http://localhost:8200/v1/sys/health",
@@ -845,10 +852,6 @@
 							"request": {
 								"method": "GET",
 								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{baseUrl}}/v1/sys/health",
 									"host": [
@@ -865,130 +868,11 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
-				},
-				{
-					"name": "02 https://localhost:8001/services",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "2bf5e87d-9b32-4514-b973-934db4f8f7fa",
-								"type": "text/javascript",
-								"exec": [
-									" /**",
-									" * Test Case:  /services - GET",
-									" * Version: Alpha",
-									" * @Author: Tingyu Zeng",
-									" * ",
-									" **/",
-									" ",
-									" tests[\"Ping Failure due to missing access token\"] = responseCode.code === 401;",
-									" tests[\"Response time is less than \"+data.responseTime+\"ms\"] = responseTime < data.responseTime;",
-									" //if(responseCode.code === 200){",
-									"   //     var contentTypeHeaderExists = responseHeaders.hasOwnProperty(\"Content-Type\");",
-									"     //   tests[\"Has Content-Type\"] = contentTypeHeaderExists;",
-									"       // if (contentTypeHeaderExists) {",
-									"        //tests[\"Content-Type is text/plain\"] =  responseHeaders[\"Content-Type\"].has(\"text/plain\");",
-									"        //}",
-									"        //if(responseBody.length!== 0){",
-									"         //   tests[\"Body is correct\"] = responseBody === \"pong\";",
-									"        //}",
-									"    //}"
-								]
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "host",
-								"value": "edgex.com"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "https://localhost:8001/services",
-							"protocol": "https",
-							"host": [
-								"localhost"
-							],
-							"port": "8001",
-							"path": [
-								"services"
-							]
-						},
-						"description": "Test service providing an indication that the service is available."
-					},
-					"response": []
-				},
-				{
-					"name": "03 http://localhost:8000/coredata/api/v1/ping",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "2bf5e87d-9b32-4514-b973-934db4f8f7fa",
-								"type": "text/javascript",
-								"exec": [
-									" /**",
-									" * Test Case:  /services - GET",
-									" * Version: Alpha",
-									" * @Author: Tingyu Zeng",
-									" * ",
-									" **/",
-									" ",
-									" tests[\"Ping Failure due to missing access token\"] = responseCode.code === 401;",
-									" tests[\"Response time is less than \"+data.responseTime+\"ms\"] = responseTime < data.responseTime;",
-									" //if(responseCode.code === 200){",
-									"   //     var contentTypeHeaderExists = responseHeaders.hasOwnProperty(\"Content-Type\");",
-									"     //   tests[\"Has Content-Type\"] = contentTypeHeaderExists;",
-									"       // if (contentTypeHeaderExists) {",
-									"        //tests[\"Content-Type is text/plain\"] =  responseHeaders[\"Content-Type\"].has(\"text/plain\");",
-									"        //}",
-									"        //if(responseBody.length!== 0){",
-									"         //   tests[\"Body is correct\"] = responseBody === \"pong\";",
-									"        //}",
-									"    //}"
-								]
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "host",
-								"value": "edgex.com"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "http://localhost:8000/coredata/api/v1/ping",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "8000",
-							"path": [
-								"coredata",
-								"api",
-								"v1",
-								"ping"
-							]
-						},
-						"description": "Test service providing an indication that the service is available."
-					},
-					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		}
 	],
 	"event": [
@@ -1218,5 +1102,6 @@
 				]
 			}
 		}
-	]
+	],
+	"protocolProfileBehavior": {}
 }

--- a/bin/postman-test/collections/security-service-docker.postman_collection.json
+++ b/bin/postman-test/collections/security-service-docker.postman_collection.json
@@ -1,17 +1,15 @@
 {
 	"info": {
-		"_postman_id": "a1cd7f2f-c5d5-4af7-a7b6-d89208852770",
+		"_postman_id": "37ed49d4-e864-4c8e-a62b-631227b93e75",
 		"name": "security-service-docker",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
 			"name": "apigateway",
-			"description": null,
 			"item": [
 				{
 					"name": "Health Check",
-					"description": null,
 					"item": [
 						{
 							"name": "01 port 8000 missing token test",
@@ -20,7 +18,6 @@
 									"listen": "test",
 									"script": {
 										"id": "56354e32-2ac1-4253-9a61-26313a54e395",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /services - GET",
@@ -30,22 +27,14 @@
 											" **/",
 											" ",
 											" tests[\"Port 8000 with missing token test\"] = responseCode.code === 401;"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "http://{{kong}}:8000/coredata/api/v1/ping",
 									"protocol": "http",
@@ -71,7 +60,6 @@
 									"listen": "test",
 									"script": {
 										"id": "e1a59e02-1650-4254-9c2a-f1ff6fa8de92",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /routes - GET",
@@ -88,22 +76,14 @@
 											"        tests[\"Content-Type is application/json\"] =  responseHeaders[\"Content-Type\"].has(\"application/json\");",
 											"        }",
 											"    }"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "http://{{kong}}:8001/",
 									"protocol": "http",
@@ -126,7 +106,6 @@
 									"listen": "test",
 									"script": {
 										"id": "4bf33d6e-3580-495d-8025-1b6aac8ac4bf",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /routes - GET",
@@ -137,22 +116,14 @@
 											" ",
 											" tests[\"Port 8443 not served\"] = responseCode.code === 404;",
 											" "
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "https://{{kong}}:8443/",
 									"protocol": "https",
@@ -175,7 +146,6 @@
 									"listen": "test",
 									"script": {
 										"id": "d00b2d72-d5d2-4f3d-bcc7-dc0a1f0e811a",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /routes - GET",
@@ -186,22 +156,14 @@
 											" ",
 											" tests[\"Port 8443 with missing token test\"] = responseCode.code === 401;",
 											" "
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "https://{{kong}}:8443/coredata/api/v1/ping",
 									"protocol": "https",
@@ -227,7 +189,6 @@
 									"listen": "test",
 									"script": {
 										"id": "3c312a45-7d5f-4d5e-ad0f-ecf0749e275f",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /routes - GET",
@@ -244,22 +205,14 @@
 											"        tests[\"Content-Type is application/json\"] =  responseHeaders[\"Content-Type\"].has(\"application/json\");",
 											"        }",
 											"    }"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "https://{{kong}}:8444/",
 									"protocol": "https",
@@ -276,11 +229,11 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
 					"name": "Proxy Check",
-					"description": null,
 					"item": [
 						{
 							"name": "01 Unauthorized token proxy access test",
@@ -289,7 +242,6 @@
 									"listen": "test",
 									"script": {
 										"id": "7dc7bbce-e60b-4988-8e2a-46b3986ad64e",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /services - GET",
@@ -300,7 +252,8 @@
 											" ",
 											" tests[\"Unauthorized Access Failure\"] = responseCode.code === 401;",
 											" "
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -309,21 +262,7 @@
 									"type": "noauth"
 								},
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									},
-									{
-										"key": "",
-										"value": "",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "https://{{kong}}:8443/coredata/api/v1/ping",
 									"protocol": "https",
@@ -349,7 +288,6 @@
 									"listen": "test",
 									"script": {
 										"id": "5d0b1fbb-7b20-4776-b9d4-7ce1fdbce22a",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /services - GET",
@@ -369,7 +307,8 @@
 											"           tests[\"Body is correct\"] = responseBody === \"pong\";",
 											"        }",
 											"    }"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -385,16 +324,7 @@
 									]
 								},
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "https://{{kong}}:8443/coredata/api/v1/ping",
 									"protocol": "https",
@@ -420,7 +350,6 @@
 									"listen": "test",
 									"script": {
 										"id": "2931833d-6335-4b99-9179-115b53179fec",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /services - GET",
@@ -431,7 +360,8 @@
 											" // execute this test case when Oauth2 authentication is configured - currently Oauth2 is by defult on apigateway",
 											" tests[\"Unauthorized token access failure test\"] = responseCode.code === 401;",
 											" "
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -447,16 +377,7 @@
 									]
 								},
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "https://{{kong}}:8443/metadata/api/v1/ping",
 									"protocol": "https",
@@ -482,14 +403,14 @@
 									"listen": "test",
 									"script": {
 										"id": "f7692439-548e-4d86-aa0b-97993f1994df",
-										"type": "text/javascript",
 										"exec": [
 											"//Assert 404 status if the reading cannot be found by id",
 											"tests[\"Status code is 404\"] = responseCode.code === 404;",
 											"",
 											"",
 											""
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -509,10 +430,6 @@
 									{
 										"key": "Content-Type",
 										"value": "application/json"
-									},
-									{
-										"key": "host",
-										"value": "edgex.com"
 									}
 								],
 								"body": {
@@ -544,7 +461,6 @@
 									"listen": "test",
 									"script": {
 										"id": "63988798-3e23-4156-905a-ebf6e8b39ca3",
-										"type": "text/javascript",
 										"exec": [
 											"/*",
 											" * Test Case:  /api/v1/reading - POST",
@@ -559,7 +475,8 @@
 											"    tests[\"Content-Type is text/plain\"] = responseHeaders[\"Content-Type\"].has(\"text/plain\");",
 											"}",
 											""
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -579,10 +496,6 @@
 									{
 										"key": "Content-Type",
 										"value": "application/json"
-									},
-									{
-										"key": "host",
-										"value": "edgex.com"
 									}
 								],
 								"body": {
@@ -608,13 +521,14 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "secretstore",
-			"description": null,
 			"item": [
 				{
 					"name": "01 health check",
@@ -653,10 +567,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "https://{{vault}}:8200/v1/sys/health",
 							"protocol": "https",
@@ -712,10 +622,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "https://{{vault}}:8200/v1/sys/key-status",
 							"protocol": "https",
@@ -775,10 +681,6 @@
 								"value": "faked"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "https://{{vault}}:8200/v1/sys/key-status",
 							"protocol": "https",
@@ -838,10 +740,6 @@
 								"value": "{{rootKey}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "https://{{vault}}:8200/v1/sys/key-status",
 							"protocol": "https",
@@ -859,7 +757,8 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		}
 	],
 	"event": [
@@ -1089,5 +988,6 @@
 				]
 			}
 		}
-	]
+	],
+	"protocolProfileBehavior": {}
 }

--- a/bin/postman-test/collections/security-service.postman_collection.json
+++ b/bin/postman-test/collections/security-service.postman_collection.json
@@ -1,13 +1,12 @@
 {
 	"info": {
-		"_postman_id": "e082c0e5-5e0e-4de9-8dd4-a07a87f796f9",
+		"_postman_id": "bec471f6-e440-4012-a7ed-935af890d923",
 		"name": "security-service",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
 			"name": "secretstore",
-			"description": null,
 			"item": [
 				{
 					"name": "01 health check",
@@ -46,10 +45,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "https://localhost:8200/v1/sys/health",
 							"protocol": "https",
@@ -105,10 +100,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "https://localhost:8200/v1/sys/key-status",
 							"protocol": "https",
@@ -168,10 +159,6 @@
 								"value": "faked"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "https://localhost:8200/v1/sys/key-status",
 							"protocol": "https",
@@ -231,10 +218,6 @@
 								"value": "{{rootKey}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "https://localhost:8200/v1/sys/key-status",
 							"protocol": "https",
@@ -252,15 +235,14 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "apigateway",
-			"description": null,
 			"item": [
 				{
 					"name": "Health Check",
-					"description": null,
 					"item": [
 						{
 							"name": "01 port 8000 missing token test",
@@ -269,7 +251,6 @@
 									"listen": "test",
 									"script": {
 										"id": "56354e32-2ac1-4253-9a61-26313a54e395",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /services - GET",
@@ -279,22 +260,14 @@
 											" **/",
 											" ",
 											" tests[\"Port 8000 with missing token test\"] = responseCode.code === 401;"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "http://localhost:8000/coredata/api/v1/ping",
 									"protocol": "http",
@@ -320,7 +293,6 @@
 									"listen": "test",
 									"script": {
 										"id": "e1a59e02-1650-4254-9c2a-f1ff6fa8de92",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /routes - GET",
@@ -337,22 +309,14 @@
 											"        tests[\"Content-Type is application/json\"] =  responseHeaders[\"Content-Type\"].has(\"application/json\");",
 											"        }",
 											"    }"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "http://localhost:8001/",
 									"protocol": "http",
@@ -375,7 +339,6 @@
 									"listen": "test",
 									"script": {
 										"id": "4bf33d6e-3580-495d-8025-1b6aac8ac4bf",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /routes - GET",
@@ -386,22 +349,14 @@
 											" ",
 											" tests[\"Port 8443 not served\"] = responseCode.code === 404;",
 											" "
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "https://localhost:8443/",
 									"protocol": "https",
@@ -424,7 +379,6 @@
 									"listen": "test",
 									"script": {
 										"id": "d00b2d72-d5d2-4f3d-bcc7-dc0a1f0e811a",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /routes - GET",
@@ -435,22 +389,14 @@
 											" ",
 											" tests[\"Port 8443 with missing token test\"] = responseCode.code === 401;",
 											" "
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "https://localhost:8443/coredata/api/v1/ping",
 									"protocol": "https",
@@ -476,7 +422,6 @@
 									"listen": "test",
 									"script": {
 										"id": "3c312a45-7d5f-4d5e-ad0f-ecf0749e275f",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /routes - GET",
@@ -493,22 +438,14 @@
 											"        tests[\"Content-Type is application/json\"] =  responseHeaders[\"Content-Type\"].has(\"application/json\");",
 											"        }",
 											"    }"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
 							"request": {
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "https://localhost:8444/",
 									"protocol": "https",
@@ -525,11 +462,11 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				},
 				{
 					"name": "Proxy Check",
-					"description": null,
 					"item": [
 						{
 							"name": "01 Unauthorized token proxy access test",
@@ -538,7 +475,6 @@
 									"listen": "test",
 									"script": {
 										"id": "7dc7bbce-e60b-4988-8e2a-46b3986ad64e",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /services - GET",
@@ -549,7 +485,8 @@
 											" ",
 											" tests[\"Unauthorized Access Failure\"] = responseCode.code === 401;",
 											" "
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -558,21 +495,7 @@
 									"type": "noauth"
 								},
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									},
-									{
-										"key": "",
-										"value": "",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "https://localhost:8443/coredata/api/v1/ping",
 									"protocol": "https",
@@ -598,7 +521,6 @@
 									"listen": "test",
 									"script": {
 										"id": "cd28dbc8-e7fa-48ee-a951-899984547683",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /services - GET",
@@ -618,7 +540,8 @@
 											"           tests[\"Body is correct\"] = responseBody === \"pong\";",
 											"        }",
 											"    }"
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -634,16 +557,7 @@
 									]
 								},
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "https://localhost:8443/coredata/api/v1/ping",
 									"protocol": "https",
@@ -669,7 +583,6 @@
 									"listen": "test",
 									"script": {
 										"id": "2931833d-6335-4b99-9179-115b53179fec",
-										"type": "text/javascript",
 										"exec": [
 											" /**",
 											" * Test Case:  /services - GET",
@@ -680,7 +593,8 @@
 											" // execute this test case when Oauth2 authentication is configured - currently Oauth2 is by defult on apigateway",
 											" tests[\"Unauthorized token access failure test\"] = responseCode.code === 401;",
 											" "
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -696,16 +610,7 @@
 									]
 								},
 								"method": "GET",
-								"header": [
-									{
-										"key": "host",
-										"value": "edgex.com"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
+								"header": [],
 								"url": {
 									"raw": "https://localhost:8443/metadata/api/v1/ping",
 									"protocol": "https",
@@ -731,14 +636,14 @@
 									"listen": "test",
 									"script": {
 										"id": "f7692439-548e-4d86-aa0b-97993f1994df",
-										"type": "text/javascript",
 										"exec": [
 											"//Assert 404 status if the reading cannot be found by id",
 											"tests[\"Status code is 404\"] = responseCode.code === 404;",
 											"",
 											"",
 											""
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -758,10 +663,6 @@
 									{
 										"key": "Content-Type",
 										"value": "application/json"
-									},
-									{
-										"key": "host",
-										"value": "edgex.com"
 									}
 								],
 								"body": {
@@ -793,7 +694,6 @@
 									"listen": "test",
 									"script": {
 										"id": "63988798-3e23-4156-905a-ebf6e8b39ca3",
-										"type": "text/javascript",
 										"exec": [
 											"/*",
 											" * Test Case:  /api/v1/reading - POST",
@@ -808,7 +708,8 @@
 											"    tests[\"Content-Type is text/plain\"] = responseHeaders[\"Content-Type\"].has(\"text/plain\");",
 											"}",
 											""
-										]
+										],
+										"type": "text/javascript"
 									}
 								}
 							],
@@ -828,10 +729,6 @@
 									{
 										"key": "Content-Type",
 										"value": "application/json"
-									},
-									{
-										"key": "host",
-										"value": "edgex.com"
 									}
 								],
 								"body": {
@@ -857,9 +754,11 @@
 							"response": []
 						}
 					],
+					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		}
 	],
 	"event": [
@@ -1089,5 +988,6 @@
 				]
 			}
 		}
-	]
+	],
+	"protocolProfileBehavior": {}
 }

--- a/bin/runSecurityserviceTest.sh
+++ b/bin/runSecurityserviceTest.sh
@@ -17,7 +17,7 @@ fi
 
 echo "Info: Initiating Securityservice Test."
 
-#OT=$(docker-compose run edgex-proxy --useradd=jerry --group=admin | tail -1)
+#OT=$(docker-compose run edgex-proxy --init=false --useradd=jerry --group=admin | tail -1)
 #TOKEN=$( echo $OT | sed 's/.*: \([^.]*\).*/\1/')
 #echo $TOKEN
 

--- a/bin/setupSecurityserviceTest.sh
+++ b/bin/setupSecurityserviceTest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-OT=$(docker-compose run edgex-proxy --useradd=jerry --group=admin | tail -1)
+OT=$(docker-compose run edgex-proxy --init=false --useradd=jerry --group=admin | tail -1)
 export TOKEN=$( echo $OT | sed 's/.*: \([^.]*\).*/\1/')
 
 #echo $TOKEN


### PR DESCRIPTION
The security-proxy-setup in Fuji release removes the requirement of setting header when sending HTTP request over proxy. This is to adjust the test cases in blackbox testing.

Signed-off-by: Tingyu Zeng <tingyu.zeng@rsa.com>