### PR TITLE
Sync the changes of nightly docker-compose file from PR 166 of developer-scripts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,35 +97,11 @@ services:
       - "IPC_LOCK"
     environment:
       - VAULT_ADDR=https://edgex-vault:8200
-      - |
-        VAULT_LOCAL_CONFIG=
-          listener "tcp" {
-              tls_disable = "0"
-              cluster_address = "edgex-vault:8201"
-              tls_min_version = "tls12"
-              tls_client_ca_file ="/run/edgex/secrets/edgex-vault/ca.pem"
-              tls_cert_file ="/run/edgex/secrets/edgex-vault/server.crt"
-              tls_key_file = "/run/edgex/secrets/edgex-vault/server.key"
-              tls_perfer_server_cipher_suites = true
-          }
-          backend "consul" {
-              path = "vault/"
-              address = "edgex-core-consul:8500"
-              scheme = "http"
-              redirect_addr = "https://edgex-vault:8200"
-              cluster_addr = "https://edgex-vault:8201"
-          }
-          default_lease_ttl = "168h"
-          max_lease_ttl = "720h"
       - VAULT_CONFIG_DIR=/vault/config
       - VAULT_UI=true
-    tmpfs:
-      - /run/edgex/secrets/edgex-vault
     command: >
       /usr/bin/dumb-init -- /bin/sh -c
-      "./security-secrets-setup generate ;
-      chown -Rh 100:1000 /run/edgex/secrets/edgex-vault/ ;
-      exec /usr/local/bin/docker-entrypoint.sh server -log-level=info"
+      "exec /usr/local/bin/docker-entrypoint.sh server -log-level=info"
     volumes:
       - vault-file:/vault/file
       - vault-logs:/vault/logs


### PR DESCRIPTION
The nightly docker-compose file from developer-scripts repository has changed due to issue [#165](https://github.com/edgexfoundry/developer-scripts/issues/165) fixes.

  This PR is to harmonized the changes of docker-compose file from the [PR #166 of developer-scripts repository](https://github.com/edgexfoundry/developer-scripts/pull/166)

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>