### PR TITLE
Update kong image to a current supported CentOS image (master)

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -23,7 +23,7 @@ export systemManagement=nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go:1
 export vault=nexus3.edgexfoundry.org:10004/docker-edgex-secret-store-go:1.1.0
 export vaultWorker=nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:1.1.0
 export kongdb=postgres:9.6
-export kong=kong:1.0.3
+export kong=kong:1.0.4-centos
 export edgexProxy=nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:1.1.0
 
 export postman=postman/newman

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,6 +178,7 @@ services:
       - 'KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl'
     depends_on:
       - kong-db
+    tty: true
 
   edgex-proxy:
     image: ${edgexProxy}


### PR DESCRIPTION
With this update kong is able to write to stdout and stderr on the sandbox. Kong should start properly now.

Fixes #305

Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>

Cherry-picked change-set from https://github.com/edgexfoundry/blackbox-testing/pull/317 merged to Fuji branch.  Needs to be merged to master as well.