### PR TITLE
Add security environment variable to run.sh script

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Set security environment variable. This is mostly cosmetic as the tests will display warnings that the env is not set.
+if [ "$SECURITY_SERVICE_NEEDED" = "true" ]; then
+	export SECURITY_IS_ON="true"
+else
+	export SECURITY_IS_ON="false"
+fi
+
 # Ensure we fail the job if any steps fail
 set -e -o pipefail
 


### PR DESCRIPTION
Fix #309

Add logic to export the necessary environment variable so that executing
the 'bin/run.sh' script does not display warnings. Adding the
environment variable does not affect anything functionality, but is
rather cosmetic to eliminate the warnings for the missing environment
variable. The missing environment variable results in a warning from the
Docker engine due to the environment variable being present in the
docker-compose file which is needed for other services.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>