### PR TITLE
Add SElinux sharing labels to all shared volume mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,9 +34,10 @@ volumes:
   vault-init:
   vault-config:
   vault-file:
-  vault-logs:
-  secrets-setup-cache:
+  vault-logs:  
   newman:
+  # non-shared volumes
+  secrets-setup-cache:
 
 services:
   volume:
@@ -45,11 +46,11 @@ services:
     networks:
       - edgex-network
     volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
-      - newman:/etc/newman
+      - db-data:/data/db:z
+      - log-data:/edgex/logs:z
+      - consul-config:/consul/config:z
+      - consul-data:/consul/data:z
+      - newman:/etc/newman:z
 
   consul:
     image: ${consul}
@@ -63,12 +64,12 @@ services:
         aliases:
           - edgex-core-consul
     volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
-      - consul-scripts:/consul/scripts
-      - vault-config:/vault/config
+      - db-data:/data/db:z
+      - log-data:/edgex/logs:z
+      - consul-config:/consul/config:z
+      - consul-data:/consul/data:z
+      - consul-scripts:/consul/scripts:z
+      - vault-config:/vault/config:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
       - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
@@ -86,10 +87,10 @@ services:
     environment:
       <<: *common-variables
     volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
+      - db-data:/data/db:z
+      - log-data:/edgex/logs:z
+      - consul-config:/consul/config:z
+      - consul-data:/consul/data:z
     depends_on:
       - volume
       - consul
@@ -114,8 +115,8 @@ services:
       - VAULT_CONFIG_DIR=/vault/config
       - VAULT_UI=true
     volumes:
-      - vault-file:/vault/file
-      - vault-logs:/vault/logs
+      - vault-file:/vault/file:z
+      - vault-logs:/vault/logs:z
       - vault-init:/vault/init:ro
       - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
     depends_on:
@@ -132,7 +133,7 @@ services:
     command: "generate"
     volumes:
       - secrets-setup-cache:/etc/edgex/pki
-      - vault-init:/vault/init
+      - vault-init:/vault/init:z
       - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     depends_on:
       - volume
@@ -147,7 +148,7 @@ services:
           - edgex-vault-worker
     volumes:
       - vault-config:/vault/config:z
-      - consul-scripts:/consul/scripts
+      - consul-scripts:/consul/scripts:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
     depends_on:
@@ -193,7 +194,7 @@ services:
         kong migrations up && kong migrations finish;
       fi'
     volumes:
-      - consul-scripts:/consul/scripts
+      - consul-scripts:/consul/scripts:ro,z
     depends_on:
       - kong-db
       - volume
@@ -229,7 +230,7 @@ services:
       "sleep 30;
       /docker-entrypoint.sh kong docker-start"
     volumes:
-      - consul-scripts:/consul/scripts
+      - consul-scripts:/consul/scripts:ro,z
     depends_on:
       - kong-db
       - kong-migrations
@@ -251,8 +252,8 @@ services:
         aliases:
           - edgex-proxy
     volumes:
-      - vault-config:/vault/config
-      - consul-scripts:/consul/scripts
+      - vault-config:/vault/config:ro,z
+      - consul-scripts:/consul/scripts:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
       - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
     depends_on:
@@ -279,9 +280,9 @@ services:
     environment:
       <<: *common-variables
     volumes:
-      - vault-config:/vault/config
-      - newman:/etc/newman
-      - consul-scripts:/consul/scripts
+      - vault-config:/vault/config:ro,z
+      - newman:/etc/newman:z
+      - consul-scripts:/consul/scripts:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     depends_on:
       - volume
@@ -300,8 +301,8 @@ services:
     environment:
       <<: *common-variables
     volumes:
-      - log-data:/edgex/logs
-      - vault-config:/vault/config
+      - log-data:/edgex/logs:z
+      - vault-config:/vault/config:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     depends_on:
       - config-seed
@@ -321,11 +322,11 @@ services:
     environment:
       <<: *common-variables
     volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
-      - vault-config:/vault/config
+      - db-data:/data/db:z
+      - log-data:/edgex/logs:z
+      - consul-config:/consul/config:z
+      - consul-data:/consul/data:z
+      - vault-config:/vault/config:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     depends_on:
       - logging
@@ -343,11 +344,11 @@ services:
     environment:
       <<: *common-variables
     volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
-      - vault-config:/vault/config
+      - db-data:/data/db:z
+      - log-data:/edgex/logs:z
+      - consul-config:/consul/config:z
+      - consul-data:/consul/data:z
+      - vault-config:/vault/config:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     depends_on:
       - logging
@@ -366,11 +367,11 @@ services:
     environment:
       <<: *common-variables
     volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
-      - vault-config:/vault/config
+      - db-data:/data/db:z
+      - log-data:/edgex/logs:z
+      - consul-config:/consul/config:z
+      - consul-data:/consul/data:z
+      - vault-config:/vault/config:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     depends_on:
       - logging
@@ -388,11 +389,11 @@ services:
     environment:
       <<: *common-variables
     volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
-      - vault-config:/vault/config
+      - db-data:/data/db:z
+      - log-data:/edgex/logs:z
+      - consul-config:/consul/config:z
+      - consul-data:/consul/data:z
+      - vault-config:/vault/config:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     depends_on:
       - metadata
@@ -410,11 +411,11 @@ services:
     environment:
       <<: *common-variables
     volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
-      - vault-config:/vault/config
+      - db-data:/data/db:z
+      - log-data:/edgex/logs:z
+      - consul-config:/consul/config:z
+      - consul-data:/consul/data:z
+      - vault-config:/vault/config:ro,z
       - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
     depends_on:
       - metadata
@@ -453,11 +454,11 @@ services:
         aliases:
           - edgex-support-rulesengine
     volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
-      - vault-config:/vault/config
+      - db-data:/data/db:z
+      - log-data:/edgex/logs:z
+      - consul-config:/consul/config:z
+      - consul-data:/consul/data:z
+      - vault-config:/vault/config:ro,z
     depends_on:
       - app-service-rules
 
@@ -472,12 +473,12 @@ services:
     environment:
       <<: *common-variables
     volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
+      - db-data:/data/db:z
+      - log-data:/edgex/logs:z
+      - consul-config:/consul/config:z
+      - consul-data:/consul/data:z
       # The following directive is to enable communication with the SMA Docker-in-Docker image (SystemManagement-Only.)
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:z
     depends_on:
       - logging
 
@@ -525,10 +526,10 @@ services:
         aliases:
           - edgex-device-virtual
     volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
+      - db-data:/data/db:z
+      - log-data:/edgex/logs:z
+      - consul-config:/consul/config:z
+      - consul-data:/consul/data:z
     depends_on:
       - data
       - command
@@ -538,7 +539,7 @@ services:
     networks:
       - edgex-network
     volumes:
-      - newman:/etc/newman
+      - newman:/etc/newman:z
 
 networks:
   edgex-network:


### PR DESCRIPTION
Add SElinux sharing labels to all *shared* volumes in
order to prevent future issues with blackbox-testing on
SElinux-enabled machines. This issue caused blackbox
testing to fail with security for Genvea release and
s partially fixed. This commit applies this change
universally.  Although this change is mainly
for host-mounted volumes, issues have been observed
for regular docker volumes as well, particularly
for dynamically created directories.

Additionally, set read-only flag on several volumes
that don't require writable shared access.

See related documentation and issues:

https://github.com/docker/docker.github.io/blob/master/storage/bind-mounts.md#configure-the-selinux-label
https://bugzilla.redhat.com/show_bug.cgi?id=1512152

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>