### PR TITLE
Enable vault-worker to R/W Vault secrets for all microservices.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,8 +149,7 @@ services:
     volumes:
       - vault-config:/vault/config:z
       - consul-scripts:/consul/scripts:ro,z
-      - /tmp/edgex/secrets/ca:/tmp/edgex/secrets/ca:ro,z
-      - /tmp/edgex/secrets/edgex-kong:/tmp/edgex/secrets/edgex-kong:ro,z
+      - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     depends_on:
       - volume
       - consul


### PR DESCRIPTION
security-secretstore-setup in conjuction with security-file-token-provider
needs to be able to generate per-service Vault tokens.  Update
the volume mount so that it has R/W access to the basedir of the
secret volumes.

Fixes #363 

Companion PR to https://github.com/edgexfoundry/edgex-go/pull/2253

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>