### PR TITLE
Fix broken security blackbox tests.

### DIFF
--- a/bin/cleanSecurityserviceTest.sh
+++ b/bin/cleanSecurityserviceTest.sh
@@ -2,6 +2,6 @@
 
 echo "Info: Clean Securityservice's test data."
 
-docker-compose -f $(ls ../ | awk '/docker-compose/ && !/test-tools/') run edgex-proxy --init=false --userdel=jerry
+docker-compose -f ../$(ls ../ | awk '/docker-compose/ && !/test-tools/') run --rm --entrypoint /edgex/security-proxy-setup edgex-proxy --init=false --userdel=jerry
 
 echo "Info: Securityservice's test data Cleaned"

--- a/bin/postman-test/collections/security-service-docker.postman_collection.json
+++ b/bin/postman-test/collections/security-service-docker.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "5b574b9d-4b39-4a66-8d81-442a27a33bfd",
+		"_postman_id": "8dcedfd2-1048-4b34-80c4-d63c067deed1",
 		"name": "security-service-docker",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -565,68 +565,12 @@
 					"response": []
 				},
 				{
-					"name": "02 mising vault keytest",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "b896f9ea-3e55-42cc-aa48-ef6d46ce4426",
-								"type": "text/javascript",
-								"exec": [
-									" /**",
-									" * Test Case:  /services - GET",
-									" * Version: Alpha",
-									" * @Author: Tingyu Zeng",
-									" * ",
-									" **/",
-									" ",
-									" tests[\"Missing secret store access check\"] = responseCode.code === 400;",
-									" ",
-									"  ",
-									" if(responseCode.code === 400){",
-									"       var contentTypeHeaderExists = responseHeaders.hasOwnProperty(\"Content-Type\");",
-									"       tests[\"Has Content-Type\"] = contentTypeHeaderExists;",
-									"       if (contentTypeHeaderExists) {",
-									"       tests[\"Content-Type is application/json\"] =  responseHeaders[\"Content-Type\"].has(\"application/json\");",
-									"       }",
-									"        if(responseBody.length!== 0){",
-									"            obj = JSON.parse(responseBody)",
-									"            tests[\"Missing token error\"] = obj.errors == \"missing client token\";",
-									"            ",
-									"        }",
-									"    }"
-								]
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "https://{{vault}}:8200/v1/sys/key-status",
-							"protocol": "https",
-							"host": [
-								"{{vault}}"
-							],
-							"port": "8200",
-							"path": [
-								"v1",
-								"sys",
-								"key-status"
-							]
-						},
-						"description": "Test service providing an indication that the service is available."
-					},
-					"response": []
-				},
-				{
 					"name": "03 unauthorized vault key test",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"id": "3d9c1ea2-fa77-4fa3-9cf7-1bac98b75adb",
-								"type": "text/javascript",
 								"exec": [
 									" /**",
 									" * Test Case:  /services - GET",
@@ -649,7 +593,8 @@
 									"            ",
 									"        }",
 									"    }"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -662,7 +607,7 @@
 							}
 						],
 						"url": {
-							"raw": "https://{{vault}}:8200/v1/sys/key-status",
+							"raw": "https://{{vault}}:8200/v1/auth/token/lookup-self",
 							"protocol": "https",
 							"host": [
 								"{{vault}}"
@@ -670,8 +615,9 @@
 							"port": "8200",
 							"path": [
 								"v1",
-								"sys",
-								"key-status"
+								"auth",
+								"token",
+								"lookup-self"
 							]
 						},
 						"description": "Test service providing an indication that the service is available."
@@ -693,7 +639,7 @@
 									" * ",
 									" **/",
 									" ",
-									" tests[\"Valid secret store access check\"] = responseCode.code !== 403;"
+									" tests[\"Valid secret store access check\"] = responseCode.code === 200;"
 								],
 								"type": "text/javascript"
 							}
@@ -704,11 +650,11 @@
 						"header": [
 							{
 								"key": "X-Vault-Token",
-								"value": "{{rootKey}}"
+								"value": "{{vaultKey}}"
 							}
 						],
 						"url": {
-							"raw": "https://{{vault}}:8200/v1/sys/key-status",
+							"raw": "https://{{vault}}:8200/v1/auth/token/lookup-self",
 							"protocol": "https",
 							"host": [
 								"{{vault}}"
@@ -716,8 +662,9 @@
 							"port": "8200",
 							"path": [
 								"v1",
-								"sys",
-								"key-status"
+								"auth",
+								"token",
+								"lookup-self"
 							]
 						},
 						"description": "Test service providing an indication that the service is available."

--- a/bin/postman-test/collections/security-service.postman_collection.json
+++ b/bin/postman-test/collections/security-service.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "bec471f6-e440-4012-a7ed-935af890d923",
+		"_postman_id": "603a5ef8-2ebc-46c9-825b-9c53f11f2a42",
 		"name": "security-service",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -63,68 +63,12 @@
 					"response": []
 				},
 				{
-					"name": "02 mising vault keytest",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "b896f9ea-3e55-42cc-aa48-ef6d46ce4426",
-								"type": "text/javascript",
-								"exec": [
-									" /**",
-									" * Test Case:  /services - GET",
-									" * Version: Alpha",
-									" * @Author: Tingyu Zeng",
-									" * ",
-									" **/",
-									" ",
-									" tests[\"Missing secret store access check\"] = responseCode.code === 400;",
-									" ",
-									"  ",
-									" if(responseCode.code === 400){",
-									"       var contentTypeHeaderExists = responseHeaders.hasOwnProperty(\"Content-Type\");",
-									"       tests[\"Has Content-Type\"] = contentTypeHeaderExists;",
-									"       if (contentTypeHeaderExists) {",
-									"       tests[\"Content-Type is application/json\"] =  responseHeaders[\"Content-Type\"].has(\"application/json\");",
-									"       }",
-									"        if(responseBody.length!== 0){",
-									"            obj = JSON.parse(responseBody)",
-									"            tests[\"Missing token error\"] = obj.errors == \"missing client token\";",
-									"            ",
-									"        }",
-									"    }"
-								]
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "https://localhost:8200/v1/sys/key-status",
-							"protocol": "https",
-							"host": [
-								"localhost"
-							],
-							"port": "8200",
-							"path": [
-								"v1",
-								"sys",
-								"key-status"
-							]
-						},
-						"description": "Test service providing an indication that the service is available."
-					},
-					"response": []
-				},
-				{
 					"name": "03 unauthorized vault key test",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"id": "3d9c1ea2-fa77-4fa3-9cf7-1bac98b75adb",
-								"type": "text/javascript",
 								"exec": [
 									" /**",
 									" * Test Case:  /services - GET",
@@ -147,7 +91,8 @@
 									"            ",
 									"        }",
 									"    }"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -160,7 +105,7 @@
 							}
 						],
 						"url": {
-							"raw": "https://localhost:8200/v1/sys/key-status",
+							"raw": "https://localhost:8200/v1/auth/token/lookup-self",
 							"protocol": "https",
 							"host": [
 								"localhost"
@@ -168,8 +113,9 @@
 							"port": "8200",
 							"path": [
 								"v1",
-								"sys",
-								"key-status"
+								"auth",
+								"token",
+								"lookup-self"
 							]
 						},
 						"description": "Test service providing an indication that the service is available."
@@ -183,7 +129,6 @@
 							"listen": "test",
 							"script": {
 								"id": "ce7f05aa-7808-4890-88c7-f10f06d94848",
-								"type": "text/javascript",
 								"exec": [
 									" /**",
 									" * Test Case:  /services - GET",
@@ -192,21 +137,9 @@
 									" * ",
 									" **/",
 									" ",
-									" tests[\"Unauthorized secret store access check\"] = responseCode.code === 200;",
-									" ",
-									" if(responseCode.code === 200){",
-									"       var contentTypeHeaderExists = responseHeaders.hasOwnProperty(\"Content-Type\");",
-									"       tests[\"Has Content-Type\"] = contentTypeHeaderExists;",
-									"       if (contentTypeHeaderExists) {",
-									"       tests[\"Content-Type is application/json\"] =  responseHeaders[\"Content-Type\"].has(\"application/json\");",
-									"       }",
-									"        if(responseBody.length!== 0){",
-									"            obj = JSON.parse(responseBody)",
-									"            tests[\"vault key term test\"] = obj.term == 1;",
-									"            ",
-									"        }",
-									"    }"
-								]
+									" tests[\"Valid secret store access check\"] = responseCode.code === 200;"
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -215,11 +148,11 @@
 						"header": [
 							{
 								"key": "X-Vault-Token",
-								"value": "{{rootKey}}"
+								"value": "{{vaultKey}}"
 							}
 						],
 						"url": {
-							"raw": "https://localhost:8200/v1/sys/key-status",
+							"raw": "https://localhost:8200/v1/auth/token/lookup-self",
 							"protocol": "https",
 							"host": [
 								"localhost"
@@ -227,8 +160,9 @@
 							"port": "8200",
 							"path": [
 								"v1",
-								"sys",
-								"key-status"
+								"auth",
+								"token",
+								"lookup-self"
 							]
 						},
 						"description": "Test service providing an indication that the service is available."

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -33,7 +33,7 @@ APPSERVICECONFIGURABLELOGSPATH=$BASEPATH/appserviceconfigurable$TIMESTAMPFORMAT.
 EDGEXLOGSPATH=$BASEPATH/edgex$TIMESTAMPFORMAT.log
 
 securityTest() {
-	$(dirname "$0")/setupSecurityserviceTest.sh
+	. $(dirname "$0")/setupSecurityserviceTest.sh
 	$(dirname "$0")/runSecurityserviceTest.sh
 	$(dirname "$0")/cleanSecurityserviceTest.sh
 }

--- a/bin/runSecurityserviceTest.sh
+++ b/bin/runSecurityserviceTest.sh
@@ -17,18 +17,10 @@ fi
 
 echo "Info: Initiating Securityservice Test."
 
-#OT=$(docker-compose -f $(ls ../ | awk '/docker-compose/ && !/test-tools/') run edgex-proxy --init=false --useradd=jerry --group=admin | tail -1)
-#TOKEN=$( echo $OT | sed 's/.*: \([^.]*\).*/\1/')
-#echo $TOKEN
-
-#RT=$(docker exec -i edgex-vault sh -c "cat /vault/config/assets/resp-init.json")
-#ROOTKEY=$(echo $RT | sed 's/.*"\(.*\)"[^"]*$/\1/')
-#echo $ROOTKEY
-
 echo "[info] ---------- use docker-compose run newman ----------"
 
 docker-compose -f ../docker-compose-test-tools.yml run --rm postman run ${COLLECTION_PATH} \
-    --environment=${ENV_PATH} --insecure --reporters="junit,cli" --global-var accessToken=$TOKEN --global-var rootKey=$ROOTKEY
+    --environment=${ENV_PATH} --insecure --reporters="junit,cli" --global-var accessToken=$TOKEN --global-var vaultKey=$VAULTKEY
 
 
 #docker run --rm --user="1000" -v "${PWD}/bin/postman-test":/etc/newman --network=${DOCKER_NETWORK} postman/newman_ubuntu1404 run ${COLLECTION_PATH} \

--- a/bin/setupSecurityserviceTest.sh
+++ b/bin/setupSecurityserviceTest.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-OT=$(docker-compose -f $(ls ../ | awk '/docker-compose/ && !/test-tools/') run edgex-proxy --init=false --useradd=jerry --group=admin | tail -1)
+OT=$(docker-compose -f ../$(ls ../ | awk '/docker-compose/ && !/test-tools/') run --rm --entrypoint /edgex/security-proxy-setup edgex-proxy --init=false --useradd=jerry --group=admin | tail -1)
 export TOKEN=$( echo $OT | sed 's/.*: \([^.]*\).*/\1/')
 
-#echo $TOKEN
+#echo TOKEN=$TOKEN
 
-RT=$(docker exec -i edgex-vault sh -c "cat /vault/config/assets/resp-init.json")
-export ROOTKEY=$(echo $RT | sed 's/.*"\(.*\)"[^"]*$/\1/')
+RT=$(docker exec -i edgex-vault-worker sh -c "cat /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json")
+export VAULTKEY=$(echo $RT | sed 's/.*"client_token":"\([^"]*\)".*/\1/')
 
-#echo $ROOTKEY
+#echo VAULTKEY=$VAULTKEY
 
 echo "Info:Securityservice Setup Completed."
 


### PR DESCRIPTION
Bring blackbox tests up-to-date to fix several broken issues:
- Attempting to create Kong user with wrong path to compose file
- Adapt creation of Kong user to override entrypoint in compose file
- Vault root token no longer exists
- Calling wrong Vault API to check for token validity
- Improperly passing environment variable from setupSecurityServiceTest.sh
  to runSecurityServiceTest.sh

Fixed #380 

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

cc: @tingyuz , @jim-wang-intel , @cloudxxx8 , @jinlinGuan 