### PR TITLE
Update to use mongo for security services

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -13,6 +13,9 @@ else
      PERSIST="-mongo"
 fi
 
+# [Workaround] there is no docker-compose-nexus-redis.yml now
+[ "$SECURITY_SERVICE_NEEDED" = true ] && PERSIST="-mongo"
+
 # nightly or other release
 USE_RELEASE=${RELEASE:-nightly-build}
 if [ "$USE_RELEASE" = "nightly-build" ]; then


### PR DESCRIPTION
Fix #394

[Workaround] use docker-compose-nexus-mongo.yml instead of docker-compose-nexus-redis.yml

Signed-off-by: Ginny Guan <ginny@iotechsys.com>