### PR TITLE
fix[security-services]: Kong access token parsing for security tests

### DIFF
--- a/bin/setupSecurityserviceTest.sh
+++ b/bin/setupSecurityserviceTest.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-OT=$(docker-compose -f ../$(ls ../ | awk '/docker-compose/ && !/test-tools/') run --rm --entrypoint /edgex/security-proxy-setup edgex-proxy --init=false --useradd=jerry --group=admin | tail -1)
-export TOKEN=$( echo $OT | sed 's/.*: \([^.]*\).*/\1/')
+OT=$(docker-compose -f ../$(ls ../ | awk '/docker-compose/ && !/test-tools/') run --rm --entrypoint /edgex/security-proxy-setup edgex-proxy --init=false --useradd=jerry --group=admin | grep '^the access token for')
+export TOKEN=$( echo $OT | sed 's/.*: \([^.]*\.[^.]*\.[^.]*\).*/\1/')
 
 #echo TOKEN=$TOKEN
 


### PR DESCRIPTION
Fixes https://github.com/edgexfoundry/edgex-go/issues/2463

Mutliple changes broke Kong access token parsing.
(1) Kong now appears to use a JWT token, and the regexp was
    fixed to parse the JWT format
(2) egdgex-proxy now has extra log messages and the logic
    (tail -1) for parsing the output was filtering out the token
    (change to grep)

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>