### PR TITLE
fix[security-services]: Kong access token parsing for security tests

### DIFF
--- a/bin/security/setupSecurityAccount.sh
+++ b/bin/security/setupSecurityAccount.sh
@@ -8,8 +8,8 @@ case ${option} in
   -useradd)
   echo "Info: Add security account."
   OT=$(docker-compose -f "${BB_ROOT_DIR}/"$(ls .. | awk '/docker-compose/ && !/test-tools/') run --rm \
-    --entrypoint /edgex/security-proxy-setup edgex-proxy --init=false --useradd=geneva --group=admin | tail -1)
-  export TOKEN=$(echo ${OT} | sed 's/.*: \([^ ]*\).*/\1/' | sed 's/\(.*\)./\1/')
+    --entrypoint /edgex/security-proxy-setup edgex-proxy --init=false --useradd=geneva --group=admin | grep '^the access token for')
+  export TOKEN=$(echo ${OT} | sed 's/.*: \([^.]*\.[^.]*\.[^.]*\).*/\1/')
   ;;
   -userdel)
   echo "Info: Delete security account."


### PR DESCRIPTION
Fixes https://github.com/edgexfoundry/edgex-go/issues/2463

Modify additional place where parsing was done.

Mutliple changes broke Kong access token parsing.
    (1) Kong now appears to use a JWT token, and the regexp was
        fixed to parse the JWT format
    (2) egdgex-proxy now has extra log messages and the logic
        (tail -1) for parsing the output was filtering out the token
        (change to grep)

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>