### PR TITLE
fix: App-service-configurable failing to start

### DIFF
--- a/docker-compose-test-tools.yml
+++ b/docker-compose-test-tools.yml
@@ -34,12 +34,11 @@ services:
     hostname: app-service-configurable
     environment:
       edgex_registry: consul://edgex-core-consul:8500
-      edgex_service: http://app-service-configurable:48095
       edgex_profile: blackbox-tests
       Service_Host: app-service-configurable
       Clients_CoreData_Host: edgex-core-data
       Clients_Logging_Host: edgex-support-logging
-      Logging_EnableRemote: "true"
+      Service_Port: 48095
       MessageBus_SubscribeHost_Host: edgex-core-data
       Database_Host: edgex-mongo
       Database_Username: appservice


### PR DESCRIPTION
app-service-configurable is failng to start due to changes
in implementation and settings. There are currently 27
assertion failures related to ASC in the blackbox tests.
This patch resolves some, but not all of these failures

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>