### PR TITLE
fix: Fixed link to nightly-build compose files to point to edgexfoundry master

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# TODO: Change URl and file spec to use edgexfoundry master once developer-scripts PR is merged
-NIGHTLY_BUILD_URL="https://raw.githubusercontent.com/lenny-intel/developer-scripts/multi2/releases/nightly-build/compose-files"
+NIGHTLY_BUILD_URL="https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/nightly-build/compose-files"
 
 # x86_64 or arm64
 [ "$(uname -m)" != "x86_64" ] && USE_ARM64="-arm64"


### PR DESCRIPTION
Just correcting the URL that previously pointed to Lenny's branch

closes #452
