### PR TITLE
Revert "Update to use Hanoi release images" to use nightly-build images

### DIFF
--- a/bin/arm64_env.sh
+++ b/bin/arm64_env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export appService=edgexfoundry/docker-app-service-configurable-arm64:1.3.0
+export appService=nexus3.edgexfoundry.org:10004/docker-app-service-configurable-arm64:master
 export postman=nexus3.edgexfoundry.org:10003/edgex-newman:4.5.6-arm64
 export docker_compose_test_tools=$PWD/docker-compose-test-tools.yml
 

--- a/bin/banner.sh
+++ b/bin/banner.sh
@@ -10,6 +10,6 @@ echo "            |___/                                              |___/  "
 echo
 echo "**********************************************************************"
 echo "                   COMPONENT BLACKBOX TEST HARNESS                    "
-echo "                        Version: Hanoi                          "
+echo "                        Version: ${RELEASE:-nightly-build}                            "
 echo "**********************************************************************"
 echo

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export appService=edgexfoundry/docker-app-service-configurable:1.3.0
+export appService=nexus3.edgexfoundry.org:10004/docker-app-service-configurable:master
 export postman=postman/newman:4.5.6
 export docker_compose_test_tools=$PWD/docker-compose-test-tools.yml
 

--- a/docs/How-to-run-blackbox-testing.md
+++ b/docs/How-to-run-blackbox-testing.md
@@ -150,7 +150,7 @@ $ bash ./bin/run.sh -cd
 
 *********************************************************************
                    COMPONENT BLACKBOX TEST HARNESS
-                           Version: Hanoi
+                           Version: Geneva
 *********************************************************************
 
 [INFO] Init postman test data .

--- a/sync.sh
+++ b/sync.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-HANOI_RELEASE_URL="https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/hanoi/compose-files"
+NIGHTLY_BUILD_URL="https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/nightly-build/compose-files"
 
 # x86_64 or arm64
 [ "$(uname -m)" != "x86_64" ] && USE_ARM64="-arm64"
@@ -8,5 +8,5 @@ HANOI_RELEASE_URL="https://raw.githubusercontent.com/edgexfoundry/developer-scri
 # security or no security
 [ "$SECURITY_SERVICE_NEEDED" != true ] && USE_NO_SECURITY="-no-secty"
 
-COMPOSE_FILE="docker-compose-hanoi${USE_NO_SECURITY}${USE_ARM64}.yml"
-curl -o docker-compose.yml "${HANOI_RELEASE_URL}/${COMPOSE_FILE}"
+COMPOSE_FILE="docker-compose-nexus${USE_NO_SECURITY}${USE_ARM64}.yml"
+curl -o docker-compose.yml "${NIGHTLY_BUILD_URL}/${COMPOSE_FILE}"


### PR DESCRIPTION
This reverts commit 42b621f126e8332415004967021937796bc98796.

Fix https://github.com/edgexfoundry/blackbox-testing/issues/472

Signed-off-by: Ginny Guan <ginny@iotechsys.com>